### PR TITLE
simple default label - helps for arquillian testing

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 template: spark
 metadata:
   name: spark
+labels:
+  app: sparkcluster
 objects:
 
 - kind: Service


### PR DESCRIPTION
cc @elmiko  @mattf @rcernich arquillian likes top level labels.  In any case, its nice to have them for resource "provenance".